### PR TITLE
Adds type conversion for the radius value in _blur_regions function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 *.pyc
+.idea/

--- a/RobotEyes/__init__.py
+++ b/RobotEyes/__init__.py
@@ -295,7 +295,7 @@ class RobotEyes(object):
             else:
                 cropped_image = im.crop((left, top, right, bottom))
 
-            blurred_image = cropped_image.filter(ImageFilter.GaussianBlur(radius=radius))
+            blurred_image = cropped_image.filter(ImageFilter.GaussianBlur(radius=float(radius)))
 
             if self.sys.lower() == "darwin":
                 im.paste(blurred_image, (left + left, top + top, right + right, bottom + bottom))


### PR DESCRIPTION
**Environment:**
OS: Windows 10
Browser: Chrome
Version: 70.0.3538.102 (Official Build) (64-bit)
Robot Framework: 3.0.4
Python: 3.7.0

**Changes and Additions:**
- Adds type conversion to float for the radius value in _blur_regions function. See issue description below.
- Updates gitignore: ignores IDE config files.

**Issue:**
This is how I'm declaring the `radius` scalar variable in my Robot Framework test case:
```
*** Variables ***
@{blur}         ${LOGIN_PASSWORD_INPUT}    ${LOGIN_BUTTON}
${tolerance}    0.05
${radius}       0.9
```

However, I was seeing the following error when using the `radius` argument in the `capture full screen` keyword:
```
TypeError: must be real number, not str
````

I narrowed down the issue to the `__init__.py` file, line 298, in the `_blur_regions` function:
```
blurred_image = cropped_image.filter(ImageFilter.GaussianBlur(radius=radius))
```
The code is expecting a float, but is interpreting (for some reason) that the argument is a string. (perhaps a Robot Framework limitation?)

**Fix:**
I implemented type convertion from string to float to that argument:
```
blurred_image = cropped_image.filter(ImageFilter.GaussianBlur(radius=float(radius)))
```

**Testing:**
- Run the Example test case (see ReadMe file) in `test` mode and play around with the `radius` value.

**Expected result:**
- The radius value should be reflected in the screenshots.
- Nothing should break regardless of entering a string or int **numerical** value (alphabetical values will obviously fail).