### PR TITLE
Improvement to ignore NoSuchElementException error

### DIFF
--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -4,6 +4,7 @@ import platform
 from PIL import Image, ImageFilter
 from robot.libraries.BuiltIn import BuiltIn
 from selenium.common.exceptions import JavascriptException
+from selenium.common.exceptions import NoSuchElementException
 
 
 class SeleniumHooks(object):
@@ -72,7 +73,10 @@ class SeleniumHooks(object):
         selectors = selectors if isinstance(selectors, list) else [selectors]
 
         for region in selectors:
-            prefix, locator, element = self.find_element(region)
+            try:
+                prefix, locator, element = self.find_element(region)
+            except NoSuchElementException:
+                continue
             area_coordinates = self._get_coordinates(prefix, locator, element)
             left, right = math.ceil(area_coordinates['left']), math.ceil(area_coordinates['right'])
             top, bottom = math.ceil(area_coordinates['top']), math.ceil(area_coordinates['bottom'])


### PR DESCRIPTION
This change will let us work with just a single array variable with all locators that must be ignored (blurred) in the screenshot.
No matter if one of the locators is not present in the current page, as it will proceed to the next locator in the array without raising exceptions.