### PR TITLE
Compare two images keyword and optional image name option for capture keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ It also serves as documentation to clarify how this library functions on a high 
 | Keyword                | Arguments                        | Comments                                                                                    |
 |------------------------|----------------------------------|---------------------------------------------------------------------------------------------|
 | Open Eyes              | lib, tolerance                   | Ex `open eyes  lib=AppiumLibrary  tolerance=5`                                                |
-| Capture Full Screen    | tolerance, blur, radius          | Ex `capture full screen  tolerance=5  blur=<array of locators>` radius=50(thickness of blur) |
-| Capture Element        | locator, tolerance, blur, radius |                                                                                             |
-| Capture Mobile Element | locator, tolerance, blur, radius |                                                                                             |
+| Capture Full Screen    | tolerance, blur, radius, name, redact          | Ex `capture full screen  tolerance=5  name=homepage  blur=<array of locators>` radius=50(thickness of blur) |
+| Capture Element        | locator, tolerance, blur, radius, name, redact |                                                                                             |
+| Capture Mobile Element | locator, tolerance, blur, radius, name, redact |                                                                                             |
 | Scroll To Element      | locator                          | Ex `scroll to element  id=user`                                                             |
 | Compare Images         |                                  | Compares all the images captured in the test with their respective base image               |
+| Compare Two Images     | first, second, output, tolerance | Compares two images captured in the above steps. Takes image names, diff file name and tolerance as arguments Ex: Compare Two Images  img1  img2  diff  10|
 
 ### Running Tests ###
 `robot -d results -v images_dir:<baseline_images_directory> tests`<br/>
@@ -190,6 +191,14 @@ Ex: ```Capture Element  <locator>  blur=id=test```
     @{blur}    id=body    css=#SIvCob
     Capture Element   <locator>  blur=${blur}
     Capture Full Screen     blur=${blur}
+```
+## Redacting elements from image
+If blurring elements does not serve your purpose, you can redact elements from images. Simply pass a list of locators that you want to redact as argument to the capture keywords.
+Ex: ```Capture Element  <locator>  redact=id=test```
+```
+    @{redact}    id=body    css=#SIvCob
+    Capture Element   <locator>  redact=${redact}
+    Capture Full Screen     redact=${redact}
 ```
 
 ## Basic Report

--- a/RobotEyes/__init__.py
+++ b/RobotEyes/__init__.py
@@ -104,6 +104,7 @@ class RobotEyes(object):
             diff_path = os.path.join(diff_path, output)
             difference = Imagemagick(first_path, second_path, diff_path).compare_images()
             color, result = self._get_result(difference, tolerance)
+            self.stats[output] = tolerance
             text = '%s %s' % (result, color)
             outfile = open(self.path + os.sep + output + '.txt', 'w')
             outfile.write(text)
@@ -226,13 +227,9 @@ class RobotEyes(object):
         return color, result
 
     def _get_baseline_dir(self):
-        try:
-            baseline_dir = BuiltIn().get_variable_value('${images_dir}')
-        except:
-            raise Exception('Please provide image baseline directory. Ex: -v images_dir:base')
-
+        baseline_dir = BuiltIn().get_variable_value('${images_dir}')
         if not baseline_dir:
-            raise Exception('Please provide image baseline directory. Ex: -v images_dir:base')
+            BuiltIn().run_keyword('Fail', 'Please provide image baseline directory. Ex: -v images_dir:base')
 
         os.makedirs(baseline_dir) if not os.path.exists(baseline_dir) else ''
         return baseline_dir
@@ -242,8 +239,10 @@ class RobotEyes(object):
 
     def _close(self):
         images_base_folder = self.images_base_folder.replace(os.getcwd(), '')[1:]
-        thread = Thread(
-            target=generate_report,
-            args=(self.baseline_dir, os.path.join(self.output_dir, 'output.xml'), images_base_folder, )
-        )
-        thread.start()
+
+        if self.baseline_dir and images_base_folder:
+            thread = Thread(
+                target=generate_report,
+                args=(self.baseline_dir, os.path.join(self.output_dir, 'output.xml'), images_base_folder, )
+            )
+            thread.start()

--- a/RobotEyes/__init__.py
+++ b/RobotEyes/__init__.py
@@ -44,13 +44,13 @@ class RobotEyes(object):
         self.count = 1
 
     # Captures full screen
-    def capture_full_screen(self, tolerance=None, blur=[], radius=50, name=None):
+    def capture_full_screen(self, tolerance=None, blur=[], radius=50, name=None, redact=[]):
         tolerance = float(tolerance) if tolerance else self.tolerance
         tolerance = tolerance/100 if tolerance >= 1 else tolerance
         name = self._get_name() if name is None else name
         name += '.png'
         path = os.path.join(self.path, name)
-        self.browser.capture_full_screen(path, blur, radius)
+        self.browser.capture_full_screen(path, blur, radius, redact)
         if self.browser.is_mobile():
             self._fix_base_image_size(path, name)
         else:
@@ -60,24 +60,24 @@ class RobotEyes(object):
         self.count += 1
 
     # Captures a specific region in a mobile screen
-    def capture_mobile_element(self, selector, tolerance=None, blur=[], radius=50, name=None):
+    def capture_mobile_element(self, selector, tolerance=None, blur=[], radius=50, name=None, redact=[]):
         tolerance = float(tolerance) if tolerance else self.tolerance
         name = self._get_name() if name is None else name
         name += '.png'
         path = os.path.join(self.path, name)
-        self.browser.capture_mobile_element(selector, path, blur, radius)
+        self.browser.capture_mobile_element(selector, path, blur, radius, redact)
         self.stats[name] = tolerance
         self.count += 1
 
     # Captures a specific region in a webpage
-    def capture_element(self, selector, tolerance=None, blur=[], radius=50, name=None):
+    def capture_element(self, selector, tolerance=None, blur=[], radius=50, name=None, redact=[]):
         tolerance = float(tolerance) if tolerance else self.tolerance
         tolerance = tolerance/100 if tolerance >= 1 else tolerance
         name = self._get_name() if name is None else name
         name += '.png'
         path = os.path.join(self.path, name)
         time.sleep(1)
-        count = self.browser.capture_element(path, selector, blur, radius)
+        self.browser.capture_element(path, selector, blur, radius, redact)
         self.stats[name] = tolerance
 
     def scroll_to_element(self, selector):
@@ -196,7 +196,6 @@ class RobotEyes(object):
         if not baseline_dir:
             raise Exception('Please provide image baseline directory. Ex: -v images_dir:base')
 
-        baseline_dir = os.path.join(os.getcwd(), baseline_dir)
         os.makedirs(baseline_dir) if not os.path.exists(baseline_dir) else ''
         return baseline_dir
 
@@ -204,8 +203,9 @@ class RobotEyes(object):
         return 'img%s' % str(self.count)
 
     def _close(self):
+        images_base_folder = self.images_base_folder.replace(os.getcwd(), '')[1:]
         thread = Thread(
             target=generate_report,
-            args=(self.baseline_dir, os.path.join(self.output_dir, 'output.xml'), self.images_base_folder, )
+            args=(self.baseline_dir, os.path.join(self.output_dir, 'output.xml'), images_base_folder, )
         )
         thread.start()

--- a/RobotEyes/__init__.py
+++ b/RobotEyes/__init__.py
@@ -193,6 +193,9 @@ class RobotEyes(object):
         except:
             raise Exception('Please provide image baseline directory. Ex: -v images_dir:base')
 
+        if not baseline_dir:
+            raise Exception('Please provide image baseline directory. Ex: -v images_dir:base')
+
         baseline_dir = os.path.join(os.getcwd(), baseline_dir)
         os.makedirs(baseline_dir) if not os.path.exists(baseline_dir) else ''
         return baseline_dir

--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -117,19 +117,7 @@ class SeleniumHooks(object):
             except NoSuchElementException:
                 continue
 
-            area_coordinates = self._get_coordinates_from_driver(element)
-
-            if self.is_mobile():
-                left, right = math.ceil(area_coordinates['left']), math.ceil(area_coordinates['right'])
-                top, bottom = math.ceil(area_coordinates['top']), math.ceil(area_coordinates['bottom'])
-            else:
-                frame_abs_pos = self._get_current_frame_abs_position()
-                left, right = math.ceil(area_coordinates['left'] + frame_abs_pos['x']), math.ceil(
-                    area_coordinates['right'] + frame_abs_pos['x'])
-                top, bottom = math.ceil(area_coordinates['top'] + frame_abs_pos['y']), math.ceil(
-                    area_coordinates['bottom'] + frame_abs_pos['y'])
-
-            left, right, top, bottom = self._update_coordinates(left, right, top, bottom)
+            left, right, top, bottom = self._get_coordinates_from_element(element)
             im = Image.open(path)
             cropped_image = im.crop((left, top, right, bottom))
             blurred_image = cropped_image.filter(ImageFilter.GaussianBlur(radius=int(radius)))
@@ -144,24 +132,27 @@ class SeleniumHooks(object):
             except NoSuchElementException:
                 continue
 
-            area_coordinates = self._get_coordinates_from_driver(element)
-
-            if self.is_mobile():
-                left, right = math.ceil(area_coordinates['left']), math.ceil(area_coordinates['right'])
-                top, bottom = math.ceil(area_coordinates['top']), math.ceil(area_coordinates['bottom'])
-            else:
-                frame_abs_pos = self._get_current_frame_abs_position()
-                left, right = math.ceil(area_coordinates['left'] + frame_abs_pos['x']), math.ceil(
-                    area_coordinates['right'] + frame_abs_pos['x'])
-                top, bottom = math.ceil(area_coordinates['top'] + frame_abs_pos['y']), math.ceil(
-                    area_coordinates['bottom'] + frame_abs_pos['y'])
-
-            left, right, top, bottom = self._update_coordinates(left, right, top, bottom)
+            left, right, top, bottom = self._get_coordinates_from_element(element)
             im = Image.open(path)
             cropped_image = im.crop((left, top, right, bottom))
             readacted_image = ImageOps.colorize(cropped_image.convert('L'), black='black', white='black')
             im.paste(readacted_image, (left, top, right, bottom))
             im.save(path)
+
+    def _get_coordinates_from_element(self, element):
+        area_coordinates = self._get_coordinates_from_driver(element)
+
+        if self.is_mobile():
+            left, right = math.ceil(area_coordinates['left']), math.ceil(area_coordinates['right'])
+            top, bottom = math.ceil(area_coordinates['top']), math.ceil(area_coordinates['bottom'])
+        else:
+            frame_abs_pos = self._get_current_frame_abs_position()
+            left, right = math.ceil(area_coordinates['left'] + frame_abs_pos['x']), math.ceil(
+                area_coordinates['right'] + frame_abs_pos['x'])
+            top, bottom = math.ceil(area_coordinates['top'] + frame_abs_pos['y']), math.ceil(
+                area_coordinates['bottom'] + frame_abs_pos['y'])
+
+        return self._update_coordinates(left, right, top, bottom)
 
     def _get_current_frame_abs_position(self):
         cmd = 'function currentFrameAbsolutePosition() { \

--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -1,4 +1,5 @@
 import math
+import os
 import platform
 
 from PIL import Image, ImageFilter
@@ -8,7 +9,6 @@ from selenium.common.exceptions import NoSuchElementException
 
 
 class SeleniumHooks(object):
-    count = 0
     mobile = False
 
     def __init__(self, lib):
@@ -29,8 +29,8 @@ class SeleniumHooks(object):
         return self.mobile
 
     def capture_full_screen(self, path, blur=[], radius=50):
-        self.count += 1
-        self.driver.save_screenshot(path + '/img' + str(self.count) + '.png')
+        self.driver.save_screenshot(path)
+
         if blur:
             self.blur_regions(blur, radius, path)
             if not self.is_mobile():
@@ -40,8 +40,6 @@ class SeleniumHooks(object):
                 self.driver.switch_to.default_content()
                 print("Switching back to initial frame and name is %s" % initial_frame)
                 self.driver.switch_to.frame(initial_frame)
-
-        return self.count
 
     def blur_in_all_frames(self, blur, radius, path):
         frames = self.driver.find_elements_by_tag_name("frame")
@@ -55,8 +53,7 @@ class SeleniumHooks(object):
             self.driver.switch_to.default_content()
 
     def capture_element(self, path, locator, blur=[], radius=50):
-        self.count += 1
-        self.driver.save_screenshot(path + '/img' + str(self.count) + '.png')
+        self.driver.save_screenshot(path)
         prefix, locator, element = self.find_element(locator)
         coord = self._get_coordinates(prefix, locator, element)
         left, right, top, bottom = self._update_coordinates(
@@ -66,27 +63,24 @@ class SeleniumHooks(object):
             math.ceil(coord['bottom'])
         )
         self.blur_regions(blur, radius, path) if blur else ''
-        im = Image.open(path + '/img' + str(self.count) + '.png')
+        im = Image.open(path)
         im = im.crop((left, top, right, bottom))
         im.resize((1024, 700), Image.ANTIALIAS)
-        im.save(path + '/img' + str(self.count) + '.png')
-        return self.count
+        im.save(path)
 
     def capture_mobile_element(self, selector, path, blur=[], radius=50):
-        self.count += 1
         prefix, locator, search_element = self.find_element(selector)
         location = search_element.location
         size = search_element.size
-        self.driver.save_screenshot(path + '/img' + str(self.count) + '.png')
+        self.driver.save_screenshot(path)
         left = location['x']
         top = location['y']
         right = location['x'] + size['width']
         bottom = location['y'] + size['height']
         self.blur_regions(blur, radius, path) if blur else ''
-        image = Image.open(path + '/img' + str(self.count) + '.png')
+        image = Image.open(path)
         image = image.crop((left, top, right, bottom))
-        image.save(path + '/img' + str(self.count) + '.png')
-        return self.count
+        image.save(path)
 
     def scroll_to_element(self, selector):
         prefix, locator, search_element = self.find_element(selector)
@@ -113,11 +107,11 @@ class SeleniumHooks(object):
                     area_coordinates['bottom'] + frame_abs_pos['y'])
 
             left, right, top, bottom = self._update_coordinates(left, right, top, bottom)
-            im = Image.open(path + '/img' + str(self.count) + '.png')
+            im = Image.open(path)
             cropped_image = im.crop((left, top, right, bottom))
             blurred_image = cropped_image.filter(ImageFilter.GaussianBlur(radius=int(radius)))
             im.paste(blurred_image, (left, top, right, bottom))
-            im.save(path + '/img' + str(self.count) + '.png')
+            im.save(path)
 
     def _get_current_frame_abs_position(self):
         cmd = 'function currentFrameAbsolutePosition() { \


### PR DESCRIPTION
- Added an optional `name` argument to all capture keywords. Images can be saved with a user specified name
- Added an optional `redact` argument similar to `blur`. This will allow redacting content from images specially when blurring content doesn't help.
- Updated the autogenerated image report to have relative path to images instead of absolute.
- Added a new keyword called `compare two images`. This will allow comparing two different images captured during the test.