### PR TITLE
Release 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ It also serves as documentation to clarify how this library functions on a high 
 | Keyword                | Arguments                        | Comments                                                                                    |
 |------------------------|----------------------------------|---------------------------------------------------------------------------------------------|
 | Open Eyes              | lib, tolerance                   | Ex `open eyes  lib=AppiumLibrary  tolerance=5`                                                |
-| Capture Full Screen    | tolerance, blur, radius          | Ex `capture full screen  tolerance=5  blur=<array of locators>` radius=50(thickness of blur) |
-| Capture Element        | locator, tolerance, blur, radius |                                                                                             |
-| Capture Mobile Element | locator, tolerance, blur, radius |                                                                                             |
+| Capture Full Screen    | tolerance, blur, radius, name, redact          | Ex `capture full screen  tolerance=5  name=homepage  blur=<array of locators>` radius=50(thickness of blur) |
+| Capture Element        | locator, tolerance, blur, radius, name, redact |                                                                                             |
+| Capture Mobile Element | locator, tolerance, blur, radius, name, redact |                                                                                             |
 | Scroll To Element      | locator                          | Ex `scroll to element  id=user`                                                             |
 | Compare Images         |                                  | Compares all the images captured in the test with their respective base image               |
+| Compare Two Images     | first, second, output, tolerance | Compares two images captured in the above steps. Takes image names, diff file name and tolerance as arguments Ex: Compare Two Images  img1  img2  diff  10|
 
 ### Running Tests ###
 `robot -d results -v images_dir:<baseline_images_directory> tests`<br/>
@@ -190,6 +191,14 @@ Ex: ```Capture Element  <locator>  blur=id=test```
     @{blur}    id=body    css=#SIvCob
     Capture Element   <locator>  blur=${blur}
     Capture Full Screen     blur=${blur}
+```
+## Redacting elements from image
+If blurring elements does not serve your purpose, you can redact elements from images. Simply pass a list of locators that you want to redact as argument to the capture keywords.
+Ex: ```Capture Element  <locator>  redact=id=test```
+```
+    @{redact}    id=body    css=#SIvCob
+    Capture Element   <locator>  redact=${redact}
+    Capture Full Screen     redact=${redact}
 ```
 
 ## Basic Report

--- a/RobotEyes/__init__.py
+++ b/RobotEyes/__init__.py
@@ -59,6 +59,7 @@ class RobotEyes(object):
         self.stats[name] = tolerance
         self.count += 1
 
+
     # Captures a specific region in a mobile screen
     def capture_mobile_element(self, selector, tolerance=None, blur=[], radius=50, name=None, redact=[]):
         tolerance = float(tolerance) if tolerance else self.tolerance
@@ -152,7 +153,7 @@ class RobotEyes(object):
                     shutil.copy(a_path, b_path)
                     text = '%s %s' % ('None', 'green')
 
-                output = open(actual_path + os.sep + filename + '.txt', 'w')
+                output = open(actual_path + os.path.sep + filename + '.txt', 'w')
                 output.write(text)
                 output.close()
         BuiltIn().run_keyword('Fail', 'Image dissimilarity exceeds tolerance') if self.fail else ''
@@ -208,7 +209,7 @@ class RobotEyes(object):
         output_dir = BuiltIn().replace_variables('${OUTPUT DIR}')
 
         if 'pabot_results' in output_dir:
-            index = output_dir.find('/pabot_results')
+            index = output_dir.find(os.path.sep + 'pabot_results')
             return output_dir[:index]
         return output_dir
 

--- a/RobotEyes/__init__.py
+++ b/RobotEyes/__init__.py
@@ -41,37 +41,86 @@ class RobotEyes(object):
         self._delete_folder_if_exists(test_name_folder)
         # recreate deleted folder
         self._create_empty_folder(test_name_folder)
+        self.count = 1
 
     # Captures full screen
-    def capture_full_screen(self, tolerance=None, blur=[], radius=50):
+    def capture_full_screen(self, tolerance=None, blur=[], radius=50, name=None, redact=[]):
         tolerance = float(tolerance) if tolerance else self.tolerance
         tolerance = tolerance/100 if tolerance >= 1 else tolerance
-        count = self.browser.capture_full_screen(self.path, blur, radius)
+        name = self._get_name() if name is None else name
+        name += '.png'
+        path = os.path.join(self.path, name)
+        self.browser.capture_full_screen(path, blur, radius, redact)
         if self.browser.is_mobile():
-            self._fix_base_image_size(self.path + '/img' + str(count) + '.png', count)
+            self._fix_base_image_size(path, name)
         else:
-            self._resize(self.path + '/img' + str(count) + '.png')
-        key = 'img' + str(count) + '.png'
-        self.stats[key] = tolerance
+            self._resize(path)
+
+        self.stats[name] = tolerance
+        self.count += 1
 
     # Captures a specific region in a mobile screen
-    def capture_mobile_element(self, selector, tolerance=None, blur=[], radius=50):
+    def capture_mobile_element(self, selector, tolerance=None, blur=[], radius=50, name=None, redact=[]):
         tolerance = float(tolerance) if tolerance else self.tolerance
-        count = self.browser.capture_mobile_element(selector, self.path, blur, radius)
-        key = 'img' + str(count) + '.png'
-        self.stats[key] = tolerance
+        name = self._get_name() if name is None else name
+        name += '.png'
+        path = os.path.join(self.path, name)
+        self.browser.capture_mobile_element(selector, path, blur, radius, redact)
+        self.stats[name] = tolerance
+        self.count += 1
 
     # Captures a specific region in a webpage
-    def capture_element(self, selector, tolerance=None, blur=[], radius=50):
+    def capture_element(self, selector, tolerance=None, blur=[], radius=50, name=None, redact=[]):
         tolerance = float(tolerance) if tolerance else self.tolerance
         tolerance = tolerance/100 if tolerance >= 1 else tolerance
+        name = self._get_name() if name is None else name
+        name += '.png'
+        path = os.path.join(self.path, name)
         time.sleep(1)
-        count = self.browser.capture_element(self.path, selector, blur, radius)
-        key = 'img' + str(count) + '.png'
-        self.stats[key] = tolerance
+        self.browser.capture_element(path, selector, blur, radius, redact)
+        self.stats[name] = tolerance
+        self.count += 1
 
     def scroll_to_element(self, selector):
         self.browser.scroll_to_element(selector)
+
+    def compare_two_images(self, first, second, output, tolerance=None):
+        tolerance = float(tolerance) if tolerance else self.tolerance
+        if not first or not second:
+            raise Exception('Please provide first and second image paths')
+
+        first_path = os.path.join(self.path, first)
+        first_path += '.png' if not first_path.endswith('.png') else ''
+        second_path = os.path.join(self.path, second) + '.png'
+        second_path += '.png' if not second_path.endswith('.png') else ''
+        output += '.png' if not output.endswith('.png') else ''
+        test_name = self.test_name.replace(' ', '_')
+        diff_path = os.path.join(self.images_base_folder, DIFF_IMAGE_BASE_FOLDER, test_name)
+
+        if os.path.exists(first_path) and os.path.exists(second_path):
+            if not os.path.exists(diff_path):
+                os.makedirs(diff_path)
+
+            diff_path = os.path.join(diff_path, output)
+            difference = Imagemagick(first_path, second_path, diff_path).compare_images()
+            color, result = self._get_result(difference, tolerance)
+            self.stats[output] = tolerance
+            text = '%s %s' % (result, color)
+            outfile = open(self.path + os.sep + output + '.txt', 'w')
+            outfile.write(text)
+            outfile.close()
+            base_path = os.path.join(self.baseline_dir, test_name, output)
+            actual_path = os.path.join(self.path, output)
+            shutil.copy(first_path, base_path)
+            shutil.copy(second_path, actual_path)
+
+            try:
+                os.remove(first_path)
+                os.remove(second_path)
+            except IOError:
+                pass
+        else:
+            raise Exception('Image %s or %s doesnt exist' % (first, second))
 
     def compare_images(self):
         test_name = self.test_name.replace(' ', '_')
@@ -103,7 +152,7 @@ class RobotEyes(object):
                     shutil.copy(a_path, b_path)
                     text = '%s %s' % ('None', 'green')
 
-                output = open(actual_path + '/' + filename + '.txt', 'w')
+                output = open(actual_path + os.sep + filename + '.txt', 'w')
                 output.write(text)
                 output.close()
         BuiltIn().run_keyword('Fail', 'Image dissimilarity exceeds tolerance') if self.fail else ''
@@ -135,9 +184,8 @@ class RobotEyes(object):
             img = img.resize((1024, 700), Image.ANTIALIAS)
             img.save(arg)
 
-    def _fix_base_image_size(self, path, count):
+    def _fix_base_image_size(self, path, image_name):
         test_name = self.test_name.replace(' ', '_')
-        image_name = 'img' + str(count) + '.png'
         base_image = os.path.join(self.baseline_dir, test_name, image_name)
         if os.path.exists(base_image):
             im = Image.open(path)
@@ -179,18 +227,22 @@ class RobotEyes(object):
         return color, result
 
     def _get_baseline_dir(self):
-        try:
-            baseline_dir = BuiltIn().get_variable_value('${images_dir}')
-        except:
-            raise Exception('Please provide image baseline directory. Ex: -v images_dir:base')
+        baseline_dir = BuiltIn().get_variable_value('${images_dir}')
+        if not baseline_dir:
+            BuiltIn().run_keyword('Fail', 'Please provide image baseline directory. Ex: -v images_dir:base')
 
-        baseline_dir = os.path.join(os.getcwd(), baseline_dir)
         os.makedirs(baseline_dir) if not os.path.exists(baseline_dir) else ''
         return baseline_dir
 
+    def _get_name(self):
+        return 'img%s' % str(self.count)
+
     def _close(self):
-        thread = Thread(
-            target=generate_report,
-            args=(self.baseline_dir, os.path.join(self.output_dir, 'output.xml'), self.images_base_folder, )
-        )
-        thread.start()
+        images_base_folder = self.images_base_folder.replace(os.getcwd(), '')[1:]
+
+        if self.baseline_dir and images_base_folder:
+            thread = Thread(
+                target=generate_report,
+                args=(self.baseline_dir, os.path.join(self.output_dir, 'output.xml'), images_base_folder, )
+            )
+            thread.start()

--- a/RobotEyes/report_generator.py
+++ b/RobotEyes/report_generator.py
@@ -57,7 +57,7 @@ def generate_report(baseline_folder, report_path, img_path):
         </thead>
         <tbody>''' % (folder_name, test_name, folder_name)
 
-        for filename in os.listdir(baseline_folder + '/' + folder_name):
+        for filename in os.listdir(baseline_folder + os.path.sep + folder_name):
             if filename.endswith('.png'):
                 html += '''<tr>'''
                 if os.path.exists(os.path.join(baseline_folder, folder_name, filename)):
@@ -81,17 +81,20 @@ def generate_report(baseline_folder, report_path, img_path):
                     html += '''<td><a href="%s" target="_blank"><img src="%s" height="200" width="350"></a></td>'''\
                             % (diff_img_path, diff_img_path)
 
-                elif os.path.exists(img_path + '/diff/' + folder_name + '/' + arr[0] + '-0.png'):
-                    diff_img_path = img_path + '/diff/' + folder_name + '/' + arr[0] + '-0.png'
+                elif os.path.exists(img_path + os.path.sep + 'diff' + os.path.sep + folder_name + os.path.sep + arr[0] + '-0.png'):
+                    diff_img_path = img_path + os.path.sep +'diff' + os.path.sep + \
+                        folder_name + os.path.sep + arr[0] + '-0.png'
                     html += '''<td><a href="%s" target="_blank"><img src="%s" height="200" width="350"></a></td>'''\
                             % (diff_img_path, diff_img_path)
 
                 else:
                     html += '''<td></td>'''
 
-                txt_file = img_path + '/actual/' + folder_name + '/' + filename + ".txt"
+                txt_file = img_path + os.path.sep + 'actual' + os.path.sep + \
+                    folder_name + os.path.sep + filename + ".txt"
                 if os.path.exists(txt_file):
-                    infile = open(img_path + '/actual/' + folder_name + '/' + filename + ".txt", 'r')
+                    infile = open(img_path + os.path.sep + 'actual' + os.path.sep + folder_name +
+                                  os.path.sep + filename + ".txt", 'r')
                     first_line = infile.readline().strip()
                     arr = first_line.split()
                     infile.close()
@@ -140,7 +143,7 @@ def generate_report(baseline_folder, report_path, img_path):
              pass = pass + 1;
             }
           });
-          
+
           $("tr.accordion-toggle").click(function () {
             classes = {
                 "fa-arrow-down": "fa-arrow-right",
@@ -149,7 +152,7 @@ def generate_report(baseline_folder, report_path, img_path):
             cls = $(this).find('i:first').attr("class").split(" ")[1];
             $(this).find('i:first').removeClass(cls).addClass(classes[cls]);
           });
-          
+
           Highcharts.chart('piechart', {
             chart: {
                 type: 'pie',
@@ -200,6 +203,6 @@ def generate_report(baseline_folder, report_path, img_path):
     </html>'''
 
     print("Creating visual report at %s/visualReport.html" % os.getcwd())
-    output = open(os.getcwd() + '/visualReport.html', 'w')
+    output = open(os.getcwd() + os.path.sep + 'visualReport.html', 'w')
     output.write(html)
     output.close()

--- a/RobotEyes/reportgen.py
+++ b/RobotEyes/reportgen.py
@@ -34,7 +34,7 @@ def report_gen():
     if opts.baseline is None:
         raise Exception('Please provide path to baseline image directory.')
 
-    if os.path.exists(root_folder + "/" + report_path) and os.path.exists(root_folder + "/" + img_path):
+    if os.path.exists(root_folder + os.path.sep + report_path) and os.path.exists(root_folder + os.path.sep + img_path):
         generate_report(opts.baseline, report_path, img_path)
     else:
         raise Exception("Please provide a valid path to results.")

--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -244,7 +244,7 @@ class SeleniumHooks(object):
                 coordinates = self.driver.execute_script(cmd)
             except JavascriptException:
                 coordinates = self._get_coordinates_from_driver(element)
-            
+
         return coordinates
 
     def _get_coordinates_from_driver(self, element):

--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -1,14 +1,13 @@
 import math
 import platform
 
-from PIL import Image, ImageFilter
+from PIL import Image, ImageFilter, ImageOps
 from robot.libraries.BuiltIn import BuiltIn
 from selenium.common.exceptions import JavascriptException
 from selenium.common.exceptions import NoSuchElementException
 
 
 class SeleniumHooks(object):
-    count = 0
     mobile = False
 
     def __init__(self, lib):
@@ -28,9 +27,9 @@ class SeleniumHooks(object):
     def is_mobile(self):
         return self.mobile
 
-    def capture_full_screen(self, path, blur=[], radius=50):
-        self.count += 1
-        self.driver.save_screenshot(path + '/img' + str(self.count) + '.png')
+    def capture_full_screen(self, path, blur=[], radius=50, redact=[]):
+        self.driver.save_screenshot(path)
+
         if blur:
             self.blur_regions(blur, radius, path)
             if not self.is_mobile():
@@ -41,7 +40,16 @@ class SeleniumHooks(object):
                 print("Switching back to initial frame and name is %s" % initial_frame)
                 self.driver.switch_to.frame(initial_frame)
 
-        return self.count
+        # User may want to blur certain elements and redact other elements at the same time.
+        if redact:
+            self._redact_regions(redact, path)
+            if not self.is_mobile():
+                initial_frame = self.driver.execute_script("return window.frameElement")
+                self.driver.switch_to.default_content()
+                self.redact_in_all_frames(redact, path)
+                self.driver.switch_to.default_content()
+                print("Switching back to initial frame and name is %s" % initial_frame)
+                self.driver.switch_to.frame(initial_frame)
 
     def blur_in_all_frames(self, blur, radius, path):
         frames = self.driver.find_elements_by_tag_name("frame")
@@ -54,9 +62,19 @@ class SeleniumHooks(object):
             self.blur_regions(blur, radius, path)
             self.driver.switch_to.default_content()
 
-    def capture_element(self, path, locator, blur=[], radius=50):
-        self.count += 1
-        self.driver.save_screenshot(path + '/img' + str(self.count) + '.png')
+    def redact_in_all_frames(self, redact, path):
+        frames = self.driver.find_elements_by_tag_name("frame")
+        iframes = self.driver.find_elements_by_tag_name("iframe")
+        joined_list = frames + iframes
+        print("Frames: %s" % str(len(joined_list)))
+        for index, frame in enumerate(joined_list):
+            print("Switching to Frame %s" % frame)
+            self.driver.switch_to.frame(frame)
+            self._redact_regions(redact, path)
+            self.driver.switch_to.default_content()
+
+    def capture_element(self, path, locator, blur=[], radius=50, redact=[]):
+        self.driver.save_screenshot(path)
         prefix, locator, element = self.find_element(locator)
         coord = self._get_coordinates(prefix, locator, element)
         left, right, top, bottom = self._update_coordinates(
@@ -66,27 +84,26 @@ class SeleniumHooks(object):
             math.ceil(coord['bottom'])
         )
         self.blur_regions(blur, radius, path) if blur else ''
-        im = Image.open(path + '/img' + str(self.count) + '.png')
+        self._redact_regions(redact, path) if redact else ''
+        im = Image.open(path)
         im = im.crop((left, top, right, bottom))
         im.resize((1024, 700), Image.ANTIALIAS)
-        im.save(path + '/img' + str(self.count) + '.png')
-        return self.count
+        im.save(path)
 
-    def capture_mobile_element(self, selector, path, blur=[], radius=50):
-        self.count += 1
+    def capture_mobile_element(self, selector, path, blur=[], radius=50, redact=[]):
         prefix, locator, search_element = self.find_element(selector)
         location = search_element.location
         size = search_element.size
-        self.driver.save_screenshot(path + '/img' + str(self.count) + '.png')
+        self.driver.save_screenshot(path)
         left = location['x']
         top = location['y']
         right = location['x'] + size['width']
         bottom = location['y'] + size['height']
         self.blur_regions(blur, radius, path) if blur else ''
-        image = Image.open(path + '/img' + str(self.count) + '.png')
+        self._redact_regions(redact, path) if redact else ''
+        image = Image.open(path)
         image = image.crop((left, top, right, bottom))
-        image.save(path + '/img' + str(self.count) + '.png')
-        return self.count
+        image.save(path)
 
     def scroll_to_element(self, selector):
         prefix, locator, search_element = self.find_element(selector)
@@ -100,24 +117,42 @@ class SeleniumHooks(object):
             except NoSuchElementException:
                 continue
 
-            area_coordinates = self._get_coordinates_from_driver(element)
-
-            if self.is_mobile():
-                left, right = math.ceil(area_coordinates['left']), math.ceil(area_coordinates['right'])
-                top, bottom = math.ceil(area_coordinates['top']), math.ceil(area_coordinates['bottom'])
-            else:
-                frame_abs_pos = self._get_current_frame_abs_position()
-                left, right = math.ceil(area_coordinates['left'] + frame_abs_pos['x']), math.ceil(
-                    area_coordinates['right'] + frame_abs_pos['x'])
-                top, bottom = math.ceil(area_coordinates['top'] + frame_abs_pos['y']), math.ceil(
-                    area_coordinates['bottom'] + frame_abs_pos['y'])
-
-            left, right, top, bottom = self._update_coordinates(left, right, top, bottom)
-            im = Image.open(path + '/img' + str(self.count) + '.png')
+            left, right, top, bottom = self._get_coordinates_from_element(element)
+            im = Image.open(path)
             cropped_image = im.crop((left, top, right, bottom))
             blurred_image = cropped_image.filter(ImageFilter.GaussianBlur(radius=int(radius)))
             im.paste(blurred_image, (left, top, right, bottom))
-            im.save(path + '/img' + str(self.count) + '.png')
+            im.save(path)
+
+    def _redact_regions(self, selectors, path):
+        selectors = selectors if isinstance(selectors, list) else [selectors]
+        for region in selectors:
+            try:
+                prefix, locator, element = self.find_element(region)
+            except NoSuchElementException:
+                continue
+
+            left, right, top, bottom = self._get_coordinates_from_element(element)
+            im = Image.open(path)
+            cropped_image = im.crop((left, top, right, bottom))
+            readacted_image = ImageOps.colorize(cropped_image.convert('L'), black='black', white='black')
+            im.paste(readacted_image, (left, top, right, bottom))
+            im.save(path)
+
+    def _get_coordinates_from_element(self, element):
+        area_coordinates = self._get_coordinates_from_driver(element)
+
+        if self.is_mobile():
+            left, right = math.ceil(area_coordinates['left']), math.ceil(area_coordinates['right'])
+            top, bottom = math.ceil(area_coordinates['top']), math.ceil(area_coordinates['bottom'])
+        else:
+            frame_abs_pos = self._get_current_frame_abs_position()
+            left, right = math.ceil(area_coordinates['left'] + frame_abs_pos['x']), math.ceil(
+                area_coordinates['right'] + frame_abs_pos['x'])
+            top, bottom = math.ceil(area_coordinates['top'] + frame_abs_pos['y']), math.ceil(
+                area_coordinates['bottom'] + frame_abs_pos['y'])
+
+        return self._update_coordinates(left, right, top, bottom)
 
     def _get_current_frame_abs_position(self):
         cmd = 'function currentFrameAbsolutePosition() { \

--- a/RobotEyes/web.py
+++ b/RobotEyes/web.py
@@ -204,7 +204,8 @@ def baseline_images():
 
     for img in imges:
         actual_path = os.path.join(results, img)
-        baseline_path = actual_path.replace('/actual/', '/baseline/')
+        baseline_path = actual_path.replace(
+            os.path.sep + 'actual' + os.path.sep, os.path.sep + 'baseline' + os.path.sep)
 
         if os.path.exists(actual_path):
             if os.path.exists(baseline_path):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.3.3'
+version = '1.4.0'
 
 setup(name='robotframework-eyes',
       version=version,


### PR DESCRIPTION
Added an optional name argument to all capture keywords. Images can be saved with a user specified name
Added an optional redact argument similar to blur. This will allow redacting content from images specially when blurring content doesn't help.
Updated the autogenerated image report to have relative path to images instead of absolute.
Added a new keyword called compare two images. This will allow comparing two different images captured during the test.
Fixes related to separator