### PR TITLE
Fix #64: Skip report gen when RobotEyes not used

### DIFF
--- a/RobotEyes/report_generator.py
+++ b/RobotEyes/report_generator.py
@@ -35,6 +35,8 @@ def generate_report(baseline_folder, report_path, img_path):
 
     tree = ET.parse(report_path)
     for t in tree.findall('.//test'):
+        if not t.findall('.//kw[@name="Open Eyes"]'):
+            continue
         test_name = t.get('name')
         folder_name = test_name.replace(' ', '_')
 


### PR DESCRIPTION
I propose to skip report generation when no `Open Eyes` keyword is used.

I hope this will not break other things