### PR TITLE
Fixing the issue of the fail attribute not existing in _end_test

### DIFF
--- a/RobotEyes/__init__.py
+++ b/RobotEyes/__init__.py
@@ -21,6 +21,7 @@ class RobotEyes(object):
     browser = None
     ROBOT_LISTENER_API_VERSION = ROBOT_LISTENER_API_VERSION
     ROBOT_LIBRARY_SCOPE = ROBOT_LIBRARY_SCOPE
+    fail = False
 
 
     # Keeping this arg to avoid exceptions for those who have added tolerance in the previous versions.


### PR DESCRIPTION
When RobotEyes is included in the RobotFramework and it isn't used, the open_eyes method is never called.
If another task triggers a failure, Robot Eyes improperly handles the error.  The self.fail attribute is set in open_eyes, but it needs to be set in either init or as a global variable for RobotEyes when it's invoked.

```[ ERROR ] Calling method '_end_test' of listener 'RobotEyes' failed: AttributeError: 'RobotEyes' object has no attribute 'fail'```

I set it as a global variable for the class.  So when open_eyes is triggered it will set the value for fail.  I set the default value to False.  This should remove the error that's encountered when other libraries have failed and RobotEyes has been included in the test suite, but open_eyes hasn't been invoked.