### PR TITLE
faet: for selenium webdriver, use find_element with selector type at first argument

### DIFF
--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -56,6 +56,12 @@ class SeleniumHooks(object):
         else:
             return self.driver.find_element(By.CSS_SELECTOR, css_selector)
 
+    def _find_elements_by_tag_name(self, tag_name):
+        if self.mobile:
+            return self.driver.find_elements_by_tag_name(tag_name)
+        else:
+            return self.driver.find_element(By.TAG_NAME, tag_name)
+
     def is_mobile(self):
         return self.mobile
 
@@ -84,8 +90,8 @@ class SeleniumHooks(object):
                 self.driver.switch_to.frame(initial_frame)
 
     def blur_in_all_frames(self, blur, radius, path):
-        frames = self.driver.find_elements_by_tag_name("frame")
-        iframes = self.driver.find_elements_by_tag_name("iframe")
+        frames = self._find_elements_by_tag_name("frame")
+        iframes = self._find_elements_by_tag_name("iframe")
         joined_list = frames + iframes
         print("Frames: %s" % str(len(joined_list)))
         for index, frame in enumerate(joined_list):
@@ -98,8 +104,8 @@ class SeleniumHooks(object):
             self.driver.switch_to.default_content()
 
     def redact_in_all_frames(self, redact, path):
-        frames = self.driver.find_elements_by_tag_name("frame")
-        iframes = self.driver.find_elements_by_tag_name("iframe")
+        frames = self._find_elements_by_tag_name("frame")
+        iframes = self._find_elements_by_tag_name("iframe")
         joined_list = frames + iframes
         print("Frames: %s" % str(len(joined_list)))
         for index, frame in enumerate(joined_list):

--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -60,7 +60,7 @@ class SeleniumHooks(object):
         if self.mobile:
             return self.driver.find_elements_by_tag_name(tag_name)
         else:
-            return self.driver.find_element(By.TAG_NAME, tag_name)
+            return self.driver.find_elements(By.TAG_NAME, tag_name)
 
     def is_mobile(self):
         return self.mobile

--- a/RobotEyes/selenium_hooks.py
+++ b/RobotEyes/selenium_hooks.py
@@ -5,6 +5,7 @@ from PIL import Image, ImageFilter, ImageOps
 from robot.libraries.BuiltIn import BuiltIn
 from selenium.common.exceptions import JavascriptException
 from selenium.common.exceptions import NoSuchElementException, NoSuchFrameException
+from selenium.webdriver.common.by import By
 
 
 class SeleniumHooks(object):
@@ -25,11 +26,35 @@ class SeleniumHooks(object):
             raise Exception('%s instance not found' % lib)
 
         self.locator_strategies = {
-            'xpath': self.driver.find_element_by_xpath,
-            'id': self.driver.find_element_by_id,
-            'class': self.driver.find_element_by_class_name,
-            'css': self.driver.find_element_by_css_selector
+            'xpath': self._find_element_by_xpath,
+            'id': self._find_element_by_id,
+            'class': self._find_element_by_class_name,
+            'css': self._find_element_by_css_selector
         }
+
+    def _find_element_by_xpath(self, xpath):
+        if self.mobile:
+            return self.driver.find_element_by_xpath(xpath)
+        else:
+            return self.driver.find_element(By.XPATH, xpath)
+
+    def _find_element_by_id(self, id):
+        if self.mobile:
+            return self.driver.find_element_by_id(id)
+        else:
+            return self.driver.find_element(By.ID, id)
+
+    def _find_element_by_class_name(self, class_name):
+        if self.mobile:
+            return self.driver.find_element_by_class_name(class_name)
+        else:
+            return self.driver.find_element(By.CLASS_NAME, class_name)
+
+    def _find_element_by_css_selector(self, css_selector):
+        if self.mobile:
+            return self.driver.find_element_by_css_selector(css_selector)
+        else:
+            return self.driver.find_element(By.CSS_SELECTOR, css_selector)
 
     def is_mobile(self):
         return self.mobile


### PR DESCRIPTION
Since selenium 4.3, find_element_by_*, which where deprecated since selenium 4, are removed.
This was blocking me to update my robotframework project with last selenium library, so providing this pull request to share, in case others have same issue.